### PR TITLE
Clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,15 @@ LDLIBS=`pkg-config --libs libpcsclite`
 all: smacget smacdig smactty
 
 smacget: smacget.o pcscwrap.o
-	$(CC) -o $@ $^ $(LDLIBS)
 
 smacget.o: smacget.c pcscwrap.h
 
 pcscwrap.o: pcscwrap.c pcscwrap.h
 
 smacdig: smacdig.o pcscwrap.o
-	$(CC) -o $@ $^ $(LDLIBS)
 
 smacdig.o: smacdig.c pcscwrap.h
 
 smactty: smactty.o pcscwrap.o
-	$(CC) -o $@ $^ $(LDLIBS)
 
 smactty.o: smactty.c pcscwrap.h

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 
 CFLAGS=-Os -Wall `pkg-config --cflags libpcsclite`
-LDFLAGS=`pkg-config --libs libpcsclite`
+LDLIBS=`pkg-config --libs libpcsclite`
 
 all: smacget smacdig smactty
 
 smacget: smacget.o pcscwrap.o
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDLIBS)
 
 smacget.o: smacget.c pcscwrap.h
 
 pcscwrap.o: pcscwrap.c pcscwrap.h
 
 smacdig: smacdig.o pcscwrap.o
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDLIBS)
 
 smacdig.o: smacdig.c pcscwrap.h
 
 smactty: smactty.o pcscwrap.o
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDLIBS)
 
 smactty.o: smactty.c pcscwrap.h

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,16 @@
 CFLAGS=-Os -Wall `pkg-config --cflags libpcsclite`
 LDLIBS=`pkg-config --libs libpcsclite`
 
+.PHONY: all
 all: smacget smacdig smactty
+
+.PHONY: clean
+clean:
+	$(RM) *.o
+
+.PHONY: distclean
+distclean: clean
+	$(RM) smacget smacdig smactty
 
 smacget: smacget.o pcscwrap.o
 


### PR DESCRIPTION
The LDFLAGS -> LDLIBS rename was actually necessary on my setup; having -l flags before the object files in the linker command line caused "undefined reference" errors.
